### PR TITLE
Improve token detection via browser support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,16 @@ This server provides access to the Shopify Storefront API via MCP, allowing AI a
 - Support for GraphQL queries and mutations
 - Automatic token handling and validation
 - Easy integration with MCP-compatible AI assistants
+- Enhanced token discovery with optional headless browsing
 
 ## Setup Instructions
 
 1. Clone this repository
 2. Install dependencies: `pip install -r requirements.txt`
-3. Copy `.env.example` to `.env` and configure your environment variables
-4. Generate a Storefront API token via Shopify Admin (see below)
-5. Run the server: `python -m shopify_storefront_mcp_server`
+3. (Optional) Install browsers for Playwright: `playwright install`
+4. Copy `.env.example` to `.env` and configure your environment variables
+5. Generate a Storefront API token via Shopify Admin (see below)
+6. Run the server: `python -m shopify_storefront_mcp_server`
 
 ## Environment Variables
 
@@ -55,9 +57,10 @@ Running with the MCP server:
 python -m shopify_storefront_mcp_server
 ```
 
+
 The server exposes the following MCP tools:
 
-- `shopify_discover`: Detect if a URL belongs to a Shopify storefront and discover authentication tokens
+- `shopify_discover`: Detect if a URL belongs to a Shopify storefront and discover authentication tokens. Pass `use_browser=True` for JS-heavy sites.
 - `shopify_storefront_graphql`: Execute GraphQL queries against the Storefront API
 - `customer_data`: Unified tool for all customer data operations (Create, Read, Update, Delete)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ httpx>=0.25.0
 python-dotenv>=1.0.0
 mcp>=0.2.0 
 bs4>=0.0.1
+playwright>=1.39.0

--- a/shopify_storefront_mcp_server/__init__.py
+++ b/shopify_storefront_mcp_server/__init__.py
@@ -1,6 +1,6 @@
 from mcp.server.fastmcp import FastMCP
 
-mcp = FastMCP("shopify_storefront", version="0.3.0")
+mcp = FastMCP("shopify_storefront", version="0.4.0")
 
 # Import submodules so that tools/resources are registered when package is loaded
 from . import customer  # noqa: F401

--- a/shopify_storefront_mcp_server/discovery.py
+++ b/shopify_storefront_mcp_server/discovery.py
@@ -4,9 +4,14 @@ import asyncio
 import json
 import re
 import urllib.parse
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 from bs4 import BeautifulSoup
+
+try:
+    from playwright.async_api import async_playwright  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    async_playwright = None
 
 from . import mcp
 from .graphql_client import GraphQLClient
@@ -30,8 +35,12 @@ HTML_MARKERS = (
 )
 
 TOKEN_PATTERNS = [
+    # New style Shopify tokens e.g. shpsa_xxx or shpat_xxx
+    re.compile(r"\b(shp[a-z]{2}_[A-Za-z0-9_-]{30,})\b", re.I),
+    # Legacy 32 char hex strings
     re.compile(r"\b([a-f0-9]{32})\b", re.I),
     re.compile(r"\b([a-f0-9]{24,64})\b", re.I),
+    # JWT style tokens
     re.compile(r"\"(eyJ[a-zA-Z0-9_-]{10,}\.eyJ[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,})\"", re.I),
 ]
 
@@ -53,6 +62,34 @@ async def fetch_head(url: str):
     client = await get_http_client()
     resp = await client.head(url, follow_redirects=True)
     return resp.headers
+
+
+async def fetch_with_browser(url: str) -> Tuple[str, Dict[str, str], List[str]]:
+    if async_playwright is None:
+        raise RuntimeError("Playwright is not installed")
+
+    tokens: List[str] = []
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        context = await browser.new_context()
+        page = await context.new_page()
+
+        async def handle_response(response):
+            for val in response.headers.values():
+                tokens.extend(_token_candidates(str(val)))
+            try:
+                body = await response.text()
+                tokens.extend(_token_candidates(body))
+            except Exception:
+                pass
+
+        page.on("response", handle_response)
+        resp = await page.goto(url)
+        await page.wait_for_load_state("networkidle")
+        html = await page.content()
+        headers = resp.headers if resp else {}
+        await browser.close()
+    return html, headers, tokens
 
 
 def _is_shopify(headers, html: str) -> bool:
@@ -77,6 +114,13 @@ def _canonical_host(html: str, fallback: str) -> str:
     if m:
         return m.group(1).lower()
     return fallback.lower()
+
+
+def _tokens_in_headers(headers) -> List[str]:
+    tokens: List[str] = []
+    for val in headers.values():
+        tokens.extend(_token_candidates(str(val)))
+    return tokens
 
 
 def _token_candidates(text: str):
@@ -165,6 +209,7 @@ async def capture_network_tokens(url: str) -> List[str]:
     candidates: List[str] = []
     client = await get_http_client()
     resp = await client.get(url)
+    candidates.extend(_tokens_in_headers(resp.headers))
     soup = BeautifulSoup(resp.text, "html.parser")
     fetch_patterns = [
         r"fetch\(['\"](https://[^'\"]+graphql[^'\"]*)['\"]",
@@ -183,7 +228,7 @@ async def capture_network_tokens(url: str) -> List[str]:
     return candidates
 
 
-async def discover_shopify(url: str, max_assets: int = 30) -> Dict[str, Any]:
+async def discover_shopify(url: str, max_assets: int = 30, use_browser: bool = False) -> Dict[str, Any]:
     result: Dict[str, Any] = {
         "shopify": False,
         "host": None,
@@ -193,7 +238,11 @@ async def discover_shopify(url: str, max_assets: int = 30) -> Dict[str, Any]:
         "notes": [],
     }
     try:
-        html, headers = await asyncio.gather(fetch_text(url), fetch_head(url))
+        if use_browser:
+            html, headers, browser_tokens = await fetch_with_browser(url)
+        else:
+            html, headers = await asyncio.gather(fetch_text(url), fetch_head(url))
+            browser_tokens = []
     except Exception as exc:
         result["notes"].append(f"initial fetch failed: {exc}")
         return result
@@ -208,26 +257,35 @@ async def discover_shopify(url: str, max_assets: int = 30) -> Dict[str, Any]:
         src = tag.get("src") or tag.get("href")
         if not src:
             continue
-        if re.search(r"(cdn\.shopify|/assets/)", src):
+        if re.search(r"(cdn\.shopify|/assets/|bundle|webpack)", src) or src.endswith(".js"):
             assets.append(urllib.parse.urljoin(url, src))
         if len(assets) >= max_assets:
             break
 
-    candidates = set(_token_candidates(html))
+    candidates_scores: Dict[str, float] = {}
+
+    def record(tokens: List[str], score: float) -> None:
+        for t in tokens:
+            if t not in candidates_scores or score > candidates_scores[t]:
+                candidates_scores[t] = score
+
+    record(_token_candidates(html), 0.3)
+    record(_tokens_in_headers(headers), 0.6)
+    record(browser_tokens, 0.7 if use_browser else 0.0)
 
     json_ld = soup.find_all("script", type="application/ld+json")
     for script in json_ld:
         if script.string:
-            candidates.update(_token_candidates(script.string))
+            record(_token_candidates(script.string), 0.3)
 
     for meta in soup.find_all("meta"):
         if meta.get("content") and len(meta.get("content", "")) > 20:
-            candidates.update(_token_candidates(meta.get("content", "")))
+            record(_token_candidates(meta.get("content", "")), 0.3)
 
     for elem in soup.find_all():
         for attr_name, value in elem.attrs.items():
             if attr_name.startswith("data-") and isinstance(value, str) and len(value) > 20:
-                candidates.update(_token_candidates(value))
+                record(_token_candidates(value), 0.3)
 
     config_patterns = [
         r"window\.[A-Za-z0-9_]+\s*=\s*({[^;]+});",
@@ -236,37 +294,45 @@ async def discover_shopify(url: str, max_assets: int = 30) -> Dict[str, Any]:
     ]
     for pattern in config_patterns:
         for match in re.finditer(pattern, html):
-            candidates.update(_token_candidates(match.group(1)))
+            record(_token_candidates(match.group(1)), 0.3)
 
     client = await get_http_client()
     for asset_url in assets:
         try:
             txt = (await client.get(asset_url)).text
-            candidates.update(_token_candidates(txt))
+            record(_token_candidates(txt), 0.4)
         except Exception as exc:
             result["notes"].append(f"asset error: {asset_url} – {exc}")
 
     try:
         network_tokens = await capture_network_tokens(url)
-        candidates.update(network_tokens)
+        record(network_tokens, 0.5)
     except Exception as exc:
         result["notes"].append(f"network token capture error: {exc}")
 
-    for tok in candidates:
+    for tok, base_score in candidates_scores.items():
         validation = await _validate_token(result["host"], tok)
         if validation["valid"]:
+            confidence = 1.0
             result["tokens_valid"].append(tok)
-            result["tokens_ranked"].append({"token": tok, "permissions": validation["permissions"]})
         else:
+            confidence = base_score
             result["tokens_invalid"].append(tok)
+        result["tokens_ranked"].append({
+            "token": tok,
+            "permissions": validation.get("permissions", []),
+            "confidence": round(confidence, 2),
+            "access_denied_errors": validation.get("access_denied_errors", []),
+        })
 
-    result["tokens_ranked"].sort(key=lambda x: len(x["permissions"]), reverse=True)
+    result["tokens_ranked"].sort(key=lambda x: x.get("confidence", 0), reverse=True)
     return result
 
 
 @mcp.tool()
-async def shopify_discover(url: str) -> str:
-    result = await discover_shopify(url)
+async def shopify_discover(url: str, use_browser: bool = False) -> str:
+    """Discover Shopify tokens and store information from a URL."""
+    result = await discover_shopify(url, use_browser=use_browser)
     if result["tokens_valid"]:
         result["api_guidance"] = []
         for token_info in result["tokens_ranked"]:


### PR DESCRIPTION
## Summary
- extend token patterns for new formats
- gather tokens from headers and Webpack bundles
- optional Playwright browser crawling
- track confidence score for each token
- document new headless option

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `playwright install chromium`


------
https://chatgpt.com/codex/tasks/task_e_683f535efcf88331a7781a6e4b700228